### PR TITLE
Updated dependency versions (grunt)

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -2,10 +2,10 @@
   "name": "distort-grid-build",
   "version": "0.0.1",
   "devDependencies": {
-    "grunt": "~0.4.1",
-    "grunt-contrib-requirejs": "~0.4.1",
-    "grunt-contrib-cssmin": "~0.6.1",
-    "grunt-contrib-copy": "~0.4.1",
-    "grunt-contrib-imagemin": "~0.3.0"
+    "grunt": "^1.3.0",
+    "grunt-contrib-copy": "^1.0.0",
+    "grunt-contrib-cssmin": "^3.0.0",
+    "grunt-contrib-imagemin": "^4.0.0",
+    "grunt-contrib-requirejs": "^1.0.0"
   }
 }


### PR DESCRIPTION
Install was failing due to older version of `grunt-contrib-imagemin`

I upgraded all dep-modules to latest, and it worked,